### PR TITLE
feat: add loading={"lazy"} attribute to CardImage

### DIFF
--- a/src/components/timeline-elements/timeline-card-media/timeline-card-media.tsx
+++ b/src/components/timeline-elements/timeline-card-media/timeline-card-media.tsx
@@ -139,6 +139,7 @@ const CardMedia: React.FunctionComponent<CardMediaModel> = ({
         visible={mediaLoaded}
         active={active}
         alt={media.name}
+        loading={"lazy"}
       />
     );
   }, [active, mediaLoaded]);

--- a/src/components/timeline-elements/timeline-card-media/timeline-card-media.tsx
+++ b/src/components/timeline-elements/timeline-card-media/timeline-card-media.tsx
@@ -139,7 +139,7 @@ const CardMedia: React.FunctionComponent<CardMediaModel> = ({
         visible={mediaLoaded}
         active={active}
         alt={media.name}
-        loading={"lazy"}
+        loading={'lazy'}
       />
     );
   }, [active, mediaLoaded]);


### PR DESCRIPTION
Hi @prabhuignoto 

Thanks for your project, it's really nicely done.

I've had an loading issue when I needed to display a frame for each card on a large timeline.
To solve this issue, I've added `loading={"lazy"}` attribute to `CardImage` component.

I'm not used to typescript component and style files, I'm not sure it's implemented rightly.

In order to use it in our project, I've published a new package called `react-chrono-lazy-loading` on https://www.npmjs.com/ :

```
yarn install react-chrono-lazy-loading
```

Thanks and have a nice day,

Alex