### PR TITLE
Added custom color for selected title

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,16 @@ The `itemWidth` prop can be used to set the width of each individual timeline se
 Customize colors with the `theme` prop.
 
 ```sh
-<Chrono items={items}  theme={{primary: "red", secondary: "blue", cardBgColor: "yellow", cardForeColor: "violet" }} />
+<Chrono
+  items={items}
+  theme={{ 
+    primary: "red",
+    secondary: "blue",
+    cardBgColor: "yellow",
+    cardForeColor: "violet",
+    titleColor: "red"
+  }}
+/>
 ```
 
 ## 📦CodeSandbox Examples

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -29,6 +29,7 @@ const Chrono: React.FunctionComponent<Partial<TimelineProps>> = (
       secondary: '#ffdf00',
       cardBgColor: '#fff',
       cardForeColor: '#000',
+      titleColor: '#0f52ba'
     },
     theme,
   );

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -29,7 +29,7 @@ const Chrono: React.FunctionComponent<Partial<TimelineProps>> = (
       secondary: '#ffdf00',
       cardBgColor: '#fff',
       cardForeColor: '#000',
-      titleColor: '#0f52ba'
+      titleColor: '#0f52ba',
     },
     theme,
   );

--- a/src/components/timeline-elements/timeline-item-title/timeline-card-title.styles.ts
+++ b/src/components/timeline-elements/timeline-item-title/timeline-card-title.styles.ts
@@ -16,6 +16,6 @@ export const TitleWrapper = styled.div<{
 
   &.active {
     background: ${(p) => p.theme?.secondary};
-    color: ${(p) => p.theme?.primary};
+    color: ${(p) => p.theme?.titleColor ? p.theme?.titleColor : p.theme?.primary};
   }
 `;

--- a/src/components/timeline-elements/timeline-item-title/timeline-card-title.styles.ts
+++ b/src/components/timeline-elements/timeline-item-title/timeline-card-title.styles.ts
@@ -16,6 +16,7 @@ export const TitleWrapper = styled.div<{
 
   &.active {
     background: ${(p) => p.theme?.secondary};
-    color: ${(p) => p.theme?.titleColor ? p.theme?.titleColor : p.theme?.primary};
+    color: ${(p) =>
+      p.theme?.titleColor ? p.theme?.titleColor : p.theme?.primary};
   }
 `;

--- a/src/demo/app-samples.tsx
+++ b/src/demo/app-samples.tsx
@@ -87,7 +87,7 @@ export const VerticalBasic: FunctionComponent<{
         slideShow
         slideItemDuration={2500}
         scrollable={{scrollbar:   false}}
-        theme={{cardBgColor:  "#fff",  cardForeColor:  "blue"}}
+        theme={{cardBgColor:  "#fff",  cardForeColor:  "blue", titleColor: "red"}}
         useReadMore={false}
       />
     </ComponentContainerTree>

--- a/src/models/Theme.ts
+++ b/src/models/Theme.ts
@@ -4,4 +4,5 @@ export interface Theme {
   textColor?: string;
   cardBgColor?: string;
   cardForeColor?: string;
+  titleColor?: string;
 }


### PR DESCRIPTION
**Added custom title color feature -**

> Pass `titleColor` property to theme object to set text color of selected title. 


Example - 
`<Chrono
	items={items}
theme={{ primary: "#0f52ba",  secondary: '#ffdf00', titleColor: 'white' }}
/>`