### PR TITLE
Fix items example at Getting Started section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When no `mode` is specified, the component defaults to `HORIZONTAL` mode. Please
     const items = [{
       title: "May 1940",
       cardTitle: "Dunkirk",
-      url: "http://www.history.com
+      url: "http://www.history.com",
       cardSubtitle:"Men of the British Expeditionary Force (BEF) wade out to..",
       cardDetailedText: "Men of the British Expeditionary Force (BEF) wade out to..",
       media: {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
At section **Getting Started**, your `items` example variable missed `"` and `,` characters (url).
Your example
```javascript
const items = [{
...
   url: "http://www.history.com
...
}, ...];
```
It should be
```javascript
const items = [{
...
   url: "http://www.history.com",
...
}, ...];
```

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [x] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/prabhuignoto/react-chrono/blob/master/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
