### PR TITLE
Allow dependent applications to programmatically set the current index

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -98,6 +98,10 @@ const Chrono: React.FunctionComponent<Partial<TimelineProps>> = (
     }
   }, []);
 
+  useEffect(() => {
+    handleTimelineUpdate(activeItemIndex);
+  }, [activeItemIndex]);
+
   const restartSlideShow = useCallback(() => {
     setSlideshowActive(true);
     handleTimelineUpdate(0);


### PR DESCRIPTION
### Description

As requested in #300 (and also because I needed it 😄), this implements a simple `useEffect` that updates `activeTimelineIndex` with `activeItemIndex`'s value on prop update.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/prabhuignoto/react-chrono/blob/master/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
