### PR TITLE
fix: settimeout trying to scroll when element is undefined

### DIFF
--- a/src/components/timeline/timeline.tsx
+++ b/src/components/timeline/timeline.tsx
@@ -207,9 +207,11 @@ const Timeline: React.FunctionComponent<TimelineModel> = (
           const { width: contentWidth, left: contentLeft } = contentRect;
           setTimeout(() => {
             const ele = horizontalContentRef.current as HTMLElement;
-            ele.style.scrollBehavior = 'smooth';
-            ele.scrollLeft +=
-              cardLeft - contentLeft + cardWidth / 2 - contentWidth / 2;
+            if(ele){ 
+              ele.style.scrollBehavior = 'smooth';
+              ele.scrollLeft +=
+                cardLeft - contentLeft + cardWidth / 2 - contentWidth / 2;
+            }
           }, 100);
         }
       }


### PR DESCRIPTION


### Description

 when using multiple chrono charts in single component, while its loading if we switch tab, it will result in error as shown in screenshot.
 
![image](https://github.com/user-attachments/assets/45ab4194-ba7c-473e-93a3-7cbaeb8aaa6d)

### Additional context

This is caused by the code

`setTimeout(() => {
            const ele = horizontalContentRef.current as HTMLElement;
              ele.style.scrollBehavior = 'smooth';
              ele.scrollLeft +=
                cardLeft - contentLeft + cardWidth / 2 - contentWidth / 2;
          }, 100);`
 
 when the settimeout of some chrono gets executed, the element might be undefined as the page might have changed.
 
 by adding if(ele) condition to make sure the element is present before initiating the scroll, we can solve this issue.

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/prabhuignoto/react-chrono/blob/master/CONTRIBUTING.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
